### PR TITLE
fix: add brave talk button on quick add not working

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Brave Talk for Google Calendar",
   "description": "Schedule Brave Talk meetings directly from Google Calendar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minimum_chrome_version": "97",
   "icons": {
     "16": "brave_talk_icon_16x.png",

--- a/src/google-calendar.ts
+++ b/src/google-calendar.ts
@@ -68,11 +68,29 @@ function addButtonToQuickAdd(quickAddDialog: HTMLElement) {
       window?.chrome?.storage?.sync?.set({ scheduleAutoCreateMeeting: "true" });
       // this is clicking the "more options" button on the quick add dialog,
       // which causes the full screen event editor to appear
-      document
-        .querySelector<HTMLElement>('div[role="button"][jsname="rhPddf"]')
-        ?.click();
+      findMoreOptionsButton()?.click();
     });
   }
+}
+
+function findMoreOptionsButton(): HTMLElement | undefined {
+  const potentialSelectors = [
+    // orignal version
+    'div[role="button"][jsname="rhPddf"]',
+    // updated as of 24 Aug 2022
+    'button[jsname="rhPddf"]',
+  ];
+
+  for (const selector of potentialSelectors) {
+    const button = document.querySelector<HTMLElement>(selector);
+    if (button) {
+      return button;
+    }
+  }
+
+  console.warn("brave-talk-gcalendar-extension: More Options button not found");
+
+  return undefined;
 }
 
 /*


### PR DESCRIPTION
fixes #19

Google have (correctly) switched from using a `<div role="button">` to just using `<button>` for the More Option element we force a click on.