### PR TITLE
Ensure "Add Brave Talk" button gets added to Quick Add

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Brave Talk for Google Calendar",
   "description": "Schedule Brave Talk meetings directly from Google Calendar",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minimum_chrome_version": "97",
   "icons": {
     "16": "brave_talk_icon_16x.png",

--- a/src/google-calendar.test.ts
+++ b/src/google-calendar.test.ts
@@ -33,33 +33,6 @@ it("should report the view family", () => {
   expect(gcal.getViewFamily()).toEqual("EVENT_EDIT");
 });
 
-it("should add button to quick add dialog", async () => {
-  document.body.outerHTML = `<body data-viewfamily="EVENT">This looks like google calendar</body>`;
-  expect(document.getElementById("jitsi_button_quick_add")).toBeNull();
-
-  gcal.watchForChanges();
-
-  expect(document.getElementById("jitsi_button_quick_add")).toBeNull();
-
-  // in real life, gcal ads a node with a dialog deep down inside
-  const dialog = document.createElement("div");
-  dialog.innerHTML = `
-    <div role="dialog">
-      <span>This is the quick add dialog</span>
-      <div id="tabEvent">
-        This tab shows event details
-      </div>
-    </div>
-  `;
-  document.body.appendChild(dialog);
-
-  // give the mutation observer a chance to run
-  await waitForMutationObserversToFire();
-
-  // we now expect the button to have been added to the quick add dialog
-  expect(document.getElementById("jitsi_button_quick_add")).not.toBeNull();
-});
-
 it("should add 'Add Brave Talk' button to full screen event edit if location is not currently brave talk", async () => {
   document.body.outerHTML = '<body data-viewfamily="EVENT_EDIT"></body>';
 

--- a/src/google-calendar.ts
+++ b/src/google-calendar.ts
@@ -37,7 +37,7 @@ export function isGoogleCalendar(): boolean {
 // The "quick add" screen is the inline event creation dialog,
 // invoked usually by clicking the "create +" button. We add a button
 // here, and get it to invoke the full-screen "edit" mode where the full functionaltiy is.
-function addButtonToQuickAdd(quickAddDialog: HTMLElement) {
+function addButtonToQuickAdd(quickAddDialog: Element) {
   // skip if our button is already added
   if (document.querySelector("#jitsi_button_quick_add")) {
     return;
@@ -242,19 +242,15 @@ export function watchForChanges() {
     // in normal calendar mode, watch for the quick add popup
     if (viewFamily === "EVENT") {
       mutations.forEach((mutation) => {
-        let dlg;
         mutation.addedNodes.forEach((node) => {
           const el =
             node instanceof HTMLElement &&
             node.querySelector("[role='dialog']");
           if (el) {
-            dlg = el;
+            window.setTimeout(() => addButtonToQuickAdd(el), 500);
             return;
           }
         });
-        if (dlg) {
-          addButtonToQuickAdd(dlg);
-        }
       });
     }
     // in full screen event edit mode, ensure our feedback button is present


### PR DESCRIPTION
It looks like the logic of this dialog has changed, in that after initail display it now gets rewritten. So the button _was_ being added, but then subequently removed.

The "fix" here is to delay a bit before trying to add the button, which generates a bit of jumpiness but seems to work reliably for me.

Fixes brave/brave-talk-gcalendar-extension#21