### PR TITLE
Fixes location of button in dialog

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Brave Talk for Google Calendar",
   "description": "Schedule Brave Talk meetings directly from Google Calendar",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "minimum_chrome_version": "97",
   "icons": {
     "16": "brave_talk_icon_16x.png",

--- a/src/brave-talk-button.ts
+++ b/src/brave-talk-button.ts
@@ -2,85 +2,139 @@
  * Generates the brave-talk button for all three calendar views
  */
 
-/** 
- * --Prior Logic-- 
- * tabPanel.innerHTML = `
-    <div class="fy8IH poWrGb">
-        <div class="FkXdCf HyA7Fb">
-          <div class="DPvwYc QusFJf jitsi_quick_add_icon"/>
-        </div>
-      <div class="kCyAyd">
-        <div class="mH89We l4V7wb">
-          <div role="button"
-              class="uArJ5e UQuaGc Y5sE8d"
-              id="jitsi_button_quick_add">
-            <content class="CwaK9 cDfbwb">
-              <span class="Fxmcue jitsi_quick_add_text_size">
-                Add a Brave Talk meeting
-              </span>
-            </content>
-          </div>
-        </div>
-      </div>
-    </div>
-    `
-*/
-export function buildQuickAddButton(tabPanel: HTMLElement) {
-  const mainDiv1 = document.createElement("div");
-  mainDiv1.setAttribute("class", "fy8IH poWrGb");
-  tabPanel.append(mainDiv1);
+function tryCloneMeetEntry() {
+  /**
+   * To ensure the button is styled appropriately, we will
+   * clone the existing Google Meet button, and modify its
+   * contents and attributes to our needs.
+   *
+   * A slightly more verbose selector is used to avoid any
+   * reliance on generated-values (e.g. jsname='abc123')
+   * which may change more frequently than the structure.
+   *
+   * TODO (Sampson): Make this work with GMail Companion.
+   */
+  const selector =
+    "[data-expandable] ~ div:has(img[src*='logo_meet']):has(button)";
+  const meetEntry = document.querySelector(selector);
 
-  // adding brave-talk logo
-  const logoDiv2 = document.createElement("div");
-  logoDiv2.setAttribute("class", "FkXdCf HyA7Fb");
-  mainDiv1.append(logoDiv2);
-  const logodDiv3 = document.createElement("div");
-  logodDiv3.setAttribute("class", "DPvwYc QusFJf jitsi_quick_add_icon");
-  logoDiv2.append(logodDiv3);
-  // adding brave-talk button
-  const btnDiv1 = document.createElement("div");
-  btnDiv1.setAttribute("class", "kCyAyd");
-  mainDiv1.append(btnDiv1);
-  const btnDiv2 = document.createElement("div");
-  btnDiv2.setAttribute("class", "mH89We l4V7wb");
-  btnDiv1.append(btnDiv2);
-  const btnDiv3 = document.createElement("div");
-  btnDiv3.setAttribute("class", "uArJ5e UQuaGc Y5sE8d");
-  btnDiv3.setAttribute("role", "button");
-  btnDiv3.setAttribute("id", "jitsi_button_quick_add");
-  btnDiv2.append(btnDiv3);
-  const btnContent4 = document.createElement("content");
-  btnContent4.setAttribute("class", "CwaK9 cDfbwb");
-  btnDiv3.append(btnContent4);
-  const btnSpan5 = document.createElement("span");
-  btnSpan5.setAttribute("class", "Fxmcue jitsi_quick_add_text_size");
-  btnSpan5.innerText = "Add a Brave Talk meeting";
-  btnContent4.append(btnSpan5);
+  if (meetEntry instanceof HTMLElement) {
+    const talkEntry = meetEntry.cloneNode(true) as HTMLElement;
+
+    // Update image and button label
+    const image = talkEntry.querySelector("img");
+    const button = talkEntry.querySelector("button");
+    const label = button?.querySelector("span");
+
+    // We require both the image and button to be present
+    if (image instanceof HTMLElement && button instanceof HTMLElement) {
+      // This ID is used to bind the click handler
+      button.id = "jitsi_button_quick_add";
+      image.src = chrome.runtime.getURL("brave_talk_icon.svg");
+
+      // TODO (Sampson): Localize this string
+      const labelText = "Add a Brave Talk meeting";
+      if (label instanceof HTMLElement) {
+        label.textContent = labelText;
+      } else {
+        button.textContent = labelText;
+      }
+
+      // Remove all js* attributes
+      const elements = talkEntry.querySelectorAll("*");
+
+      for (const item of [talkEntry, ...Array.from(elements)]) {
+        for (const attribute of Array.from(item.attributes)) {
+          if (attribute.name.startsWith("js")) {
+            item.removeAttribute(attribute.name);
+          }
+        }
+      }
+
+      return talkEntry;
+    }
+  }
+
+  return false;
 }
 
-/** 
- * --Prior Logic-- 
- * buttonRow.innerHTML = `
-      <div class="tzcF6">
-        <div class="DPvwYc jitsi_edit_page_icon"></div>
-      </div>
-      <div class="j3nyw">
-        <div class="BY5aAd">
-          <div role="button"
-               class="uArJ5e UQuaGc Y5sE8d"
-               id="jitsi_button_container">
-            <content class="CwaK9">
-              <div id="jitsi_button" 
-                  class="goog-inline-block jfk-button jfk-button-action jfk-button-clear-outline">
-                <a href="#" style="color: white"></a>
-              </div>
-            </content>
-          </div>
-        </div>
-      </div>
-  `;
-*/
+export function buildQuickAddButton(tabPanel: HTMLElement) {
+  /**
+   * We'll initially try to clone the Google Meet
+   * button to match its structure and styling.
+   */
+  const talkEntry = tryCloneMeetEntry();
 
+  if (talkEntry instanceof HTMLElement) {
+    console.log("Successfully cloned Meet button");
+    tabPanel.append(talkEntry);
+    return;
+  }
+
+  /**
+   * We'll fall-back to what the button looked
+   * like most recently (as of 2023-06-21). We
+   * have no assurance that any of these class
+   * names will remain stable.
+   */
+
+  console.log("Clone failure. Falling back to last-known button.");
+
+  // prettier-ignore
+  const element = el( "div", { class: "m2hqkd" },
+    el("div", { class: "fy8IH xI9Bs FrRgdd" },
+      el("div", { class: "FkXdCf HyA7Fb" },
+        el("i", { class: "google-material-icons meh4fc hggPq GyffFb", "aria-hidden": "true" },
+          el("div", {},
+            el("img", { class: "Gxo8Ie", src: chrome.runtime.getURL("brave_talk_icon.svg"), "aria-hidden": "true" })))),
+      el("div", { class: "tsUyod XsN7kf", "data-dragsource-ignore": "true" },
+        el("div", { class: "lulit" },
+          el("div", { class: "d27AIf z5I5rf s2r4Od", "data-in-bubble": "true" },
+            el("div", { class: "oJeWuf" },
+              el("div", { class: "emaTS yLISWd" },
+                el("div", { class: "Kh5Sib FAE19b", "data-use-button-for-single-solution": "true" },
+                  el("button", { class: "VfPpkd-LgbsSe VfPpkd-LgbsSe-OWXEXe-k8QpJ nCP5yc AjY5Oe DuMIQc LQeN7 JTAoxf Z1uZib",
+                    id: "jitsi_button_quick_add",
+                    "data-idom-class": "nCP5yc AjY5Oe DuMIQc LQeN7 JTAoxf Z1uZib",
+                    "data-solution": "W1szXV0." },
+                    el("div", { class: "VfPpkd-Jh9lGc" }),
+                    el("div", { class: "VfPpkd-J1Ukfc-LhBDec" }),
+                    el("span", { class: "VfPpkd-vQzf8d" },
+                      "Add a Brave Talk meeting"
+                    )))),
+              el("div", { class: "jekkF x5Urbb" })))))));
+
+  tabPanel.appendChild(element);
+}
+
+function el(
+  tag: keyof HTMLElementTagNameMap,
+  attrs: Record<string, string>,
+  ...children: any[]
+): HTMLElement {
+  const element = document.createElement(tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    element.setAttribute(key, value);
+  }
+  for (const child of children) {
+    if (typeof child === "string") {
+      element.appendChild(document.createTextNode(child));
+    } else {
+      element.appendChild(child);
+    }
+  }
+  return element;
+}
+
+/**
+ * TODO (Sampson): Revisit to see if we can
+ * combine this and buildQuickAddButton into
+ * a single function.
+ *
+ * At the very least, we need to update the
+ * class names used here, as well as localize
+ * the strings.
+ */
 export function buildFullScreenAddButton(buttonRow: HTMLElement) {
   // adding brave-talk logo
   const logoDiv1 = document.createElement("div");

--- a/src/google-calendar.ts
+++ b/src/google-calendar.ts
@@ -42,7 +42,7 @@ function addButtonToQuickAdd(quickAddDialog: Element) {
   if (document.querySelector("#jitsi_button_quick_add")) {
     return;
   }
-  const tabEvent = quickAddDialog.querySelector("#tabEvent");
+  const tabEvent = quickAddDialog.querySelector("[aria-labelledby=tabEvent]");
   if (tabEvent) {
     const tabPanel = document.createElement("content");
     tabPanel.setAttribute("role", "tabpanel");
@@ -242,11 +242,32 @@ export function watchForChanges() {
     // in normal calendar mode, watch for the quick add popup
     if (viewFamily === "EVENT") {
       mutations.forEach((mutation) => {
+        /**
+         * TODO (Sampson): Listen also for attribute changes.
+         * When the user switches from the "Event" tab to the
+         * "Tasks" tab, then back to "Event", no nodes are
+         * added. Instead, the visibility of the existing
+         * Event node is toggled.
+         *
+         * There exists a bug now where opening the dialog
+         * too soon after page-load can result in the button
+         * being added, then promptly removed. I suspect this
+         * is due to the view of the dialog being refreshed
+         * after it has already been opened. Listening for
+         * attribute changes may help us to avoid getting
+         * dropped when the component is refreshed.
+         */
         mutation.addedNodes.forEach((node) => {
           const el =
             node instanceof HTMLElement &&
             node.querySelector("[role='dialog']");
           if (el) {
+            /**
+             * TODO (Sampson): Revisit to take an alternative
+             * approach here. Rather than use a timeout, we
+             * can instead poll the DOM for the presence of
+             * expected elements (e.g. `waitForSelector`).
+             */
             window.setTimeout(() => addButtonToQuickAdd(el), 500);
             return;
           }
@@ -310,9 +331,7 @@ function addButtonToGmailCal(quickAddDialog: HTMLElement) {
       window?.chrome?.storage?.sync?.set({ scheduleAutoCreateMeeting: "true" });
       // this is clicking the "Edit in calendar" button on the top-right corner,
       // which causes the full screen event editor to appear
-      document
-        .querySelector<HTMLElement>('div[role="button"][jsname="ZkN63"]')
-        ?.click();
+      document.querySelector<HTMLElement>('button[jsname="ZkN63"]')?.click();
     });
   }
 }


### PR DESCRIPTION
Address #25 

It appears the target element is not longer identified by `[id=tabEvent]`, but now can be found via `[aria-labelledby=tabEvent]`. Updating our selector enables us to find the desired element. Some of our class names were based on an earlier version of GCal, and were no longer useful.

This PR introduces a new method (i.e. `tryCloneMeetEntry()`) which creates a clone of the Google Meet button. This clone enables us to maintain similar structure and style to the Google Meet button. If the button cannot be cloned (e.g. perhaps it doesn't exist in the user's session), then we fall back to manually constructing a button. This PR attempts to construct an element which mimics the current Google Meet element structure.

I also added a small helper function (i.e. `el()`) which enables us to maintain the visible structure of a DOM element tree without needing its markup. This is to help maintain the fallback behavior of manually constructing a button when the Google Meet button is not present, or cannot be cloned.

- Bumps version to 1.0.3.
- Adds a few TODO items.
- Restores button for Gmail Companion widget.