### PR TITLE
Google Calendar Improvements

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
   "default_locale": "en_US",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "minimum_chrome_version": "97",
   "icons": {
     "16": "brave_talk_icon_16x.png",

--- a/src/common.ts
+++ b/src/common.ts
@@ -4,6 +4,17 @@ export async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export function isElementVisible(element: HTMLElement): boolean {
+  if (element instanceof HTMLElement) {
+    const { display, opacity, visibility } = window.getComputedStyle(element);
+    if (display !== "none" && visibility !== "hidden" && opacity !== "0") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export async function waitForSelectorAndPause<T extends HTMLElement>(
   page: Page,
   selector: string,

--- a/src/common.ts
+++ b/src/common.ts
@@ -147,6 +147,35 @@ export function simulateFocusEvents(
     element.dispatchEvent(new FocusEvent(eventType, { bubbles: true }));
   }
 }
+
+export function setFieldValue(
+  element: HTMLInputElement | HTMLTextAreaElement,
+  value: string
+): void {
+  const focused = document.activeElement;
+
+  simulateFocusEvents(element, "focus");
+
+  /**
+   * As is the case with FocusEvents above and below, we
+   * are simulating several keyboard and input events to
+   * ensure Skiff Calendar's internal state is updated.
+   */
+  element.value = value;
+  for (const type of ["keydown", "keypress", "input", "keyup"]) {
+    element.dispatchEvent(new Event(type, { bubbles: true }));
+  }
+
+  simulateFocusEvents(element, "blur");
+
+  /**
+   * Restore focus to original element, if needed.
+   */
+  if (focused instanceof HTMLElement) {
+    simulateFocusEvents(focused, "focus");
+  }
+}
+
 /**
  *
  * @param tag Tag name of the element to create.

--- a/src/skiff/calendar.ts
+++ b/src/skiff/calendar.ts
@@ -21,7 +21,7 @@ export const LOCATION_FIELD_SELECTOR = "[data-test='location-input-field']";
 export const CANCEL_BUTTON_SELECTOR = "[data-test='dialog-cancel']";
 export const CONFIRM_REMOVE_BUTTON_SELECTOR = "[data-test='confirm-Remove']";
 
-import { clickElement, createElement, simulateFocusEvents } from "../common";
+import { clickElement, createElement, setFieldValue } from "../common";
 
 export function isSkiff(address?: string): boolean {
   let url: URL = new URL(address ? address : window.location.href);
@@ -172,35 +172,6 @@ export function getBraveMeeting(): URL | null {
   }
 
   return null;
-}
-
-// TODO (Sampson): Move this to common.ts
-export function setFieldValue(
-  element: HTMLInputElement | HTMLTextAreaElement,
-  value: string
-): void {
-  const focused = document.activeElement;
-
-  simulateFocusEvents(element, "focus");
-
-  /**
-   * As is the case with FocusEvents above and below, we
-   * are simulating several keyboard and input events to
-   * ensure Skiff Calendar's internal state is updated.
-   */
-  element.value = value;
-  for (const type of ["keydown", "keypress", "input", "keyup"]) {
-    element.dispatchEvent(new Event(type, { bubbles: true }));
-  }
-
-  simulateFocusEvents(element, "blur");
-
-  /**
-   * Restore focus to original element, if needed.
-   */
-  if (focused instanceof HTMLElement) {
-    simulateFocusEvents(focused, "focus");
-  }
 }
 
 export function handleButtonClick(event: MouseEvent): void {

--- a/src/tests/google/authenticate.ts
+++ b/src/tests/google/authenticate.ts
@@ -83,15 +83,19 @@ async function authenticateUserLoginCaptcha(page: Page): Promise<void> {
     .waitForSelector(auth.selectors.NEXT_BUTTON, options)
     .then((elementHandle) => elementHandle?.click());
 
-  await page.waitForSelector(auth.selectors.CAPTCHA_IMAGE, options);
+  try {
+    await page.waitForSelector(auth.selectors.CAPTCHA_IMAGE, options);
 
-  /**
-   * We've come across a captcha image. We will wait for up to 60 seconds
-   * for the user to solve the captcha. If the user does not solve the
-   * captcha in time, we will throw an error.
-   */
+    /**
+     * We've come across a captcha image. We will wait for up to 60 seconds
+     * for the user to solve the captcha. If the user does not solve the
+     * captcha in time, we will throw an error.
+     */
 
-  console.log("google:authenticateUserLoginCaptcha: waiting for solution");
+    console.log("google:authenticateUserLoginCaptcha: waiting for solution");
+  } catch (e) {
+    console.log("google:authenticateUserLoginCaptcha: no captcha found");
+  }
 
   await page
     .waitForSelector(
@@ -194,10 +198,14 @@ export async function authenticateUser(page: Page): Promise<void> {
     throw new Error("AUTH_URL not found");
   }
 
-  await page.goto(auth.AUTH_URL, {
-    waitUntil: "networkidle0",
-    timeout: 5_000,
-  });
+  await page
+    .goto(auth.AUTH_URL, {
+      waitUntil: "networkidle0",
+      timeout: 5_000,
+    })
+    .catch(() => {
+      console.log("google:authenticateUser: page didn't idle in time");
+    });
 
   const pageType = await getPageType(page);
 

--- a/src/tests/google/calendar.test.ts
+++ b/src/tests/google/calendar.test.ts
@@ -26,7 +26,7 @@ describe("Google Calendar", () => {
     await setupAuthenticatedBrowserSession(authenticateUser, state).catch(
       (error) => {
         console.log(error);
-        console.error("An authentication session could not be established");
+        console.error("An authenticated session could not be established");
         // Don't attempt to do any further testing
         process.exit(1);
       }
@@ -70,6 +70,40 @@ describe("Google Calendar", () => {
       Google.TALK_BUTTON_SELECTOR,
       options
     );
+    expect(braveTalkButton).toBeTruthy();
+  });
+
+  it("Persists button between panel selections", async () => {
+    /**
+     * See the following:
+     * https://github.com/brave/brave-talk-gcalendar-extension/issues/34
+     */
+
+    console.log("google:buttonPersistsBetweenPanels");
+
+    const options = { visible: true, timeout: 5_000 };
+
+    const eventTab = await state.page.waitForSelector(
+      Google.EVENT_TAB_BUTTON_SELECTOR,
+      options
+    );
+
+    const taskTab = await state.page.waitForSelector(
+      Google.TASK_TAB_BUTTON_SELECTOR,
+      options
+    );
+
+    await taskTab?.click();
+    await sleep(1_000);
+
+    await eventTab?.click();
+    await sleep(1_000);
+
+    const braveTalkButton = await state.page.waitForSelector(
+      Google.TALK_BUTTON_SELECTOR,
+      options
+    );
+
     expect(braveTalkButton).toBeTruthy();
   });
 


### PR DESCRIPTION
This change adds observance of attribute mutations, enabling us to ensure the Brave Talk button is always visible, as well as freeing us from the need to rely on `setTimeout` when adding the Brave Talk button to the UI. This PR addresses Issue #34.

Tests were updated to address an authentication problem, as well as to include a scenario to check that Issue #34 is not regressed in a future update. To manually check this update, toggle between "Event" and "Task" panels, checking that the Brave Talk button remains visible in the process.

![button-persists](https://github.com/brave/brave-talk-gcalendar-extension/assets/815158/8d3a4efa-ae1d-4214-b9ed-4e88ca2b497d)

This PR also updates the `tryCloneMeetEntry` to support the Calendar Companion view. Before, only the Meet Button from the calendar could be cloned. The companion view would get a fallback button, which didn't match the theme. The companion Talk button structure and aesthetics are now based on the Meet button, if present:

![image](https://github.com/brave/brave-talk-gcalendar-extension/assets/815158/1b33e8c6-f6e5-4481-b8e9-011a68a78d0d)
