### PR TITLE
Updates selector for label-targetting

### DIFF
--- a/src/brave/brave-talk-button.ts
+++ b/src/brave/brave-talk-button.ts
@@ -29,7 +29,7 @@ function tryCloneMeetEntry() {
     // Update image and button label
     const image = talkEntry.querySelector("img, svg");
     const button = talkEntry.querySelector("button");
-    const label = button?.querySelector("span");
+    const label = button?.querySelector("span[jsname='V67aGc']");
 
     // We require both the image and button to be present
     if (image instanceof Element && button instanceof HTMLElement) {


### PR DESCRIPTION
It appears a recent change to the GCal DOM has impacted our ability to locate the proper label element. There now appear to be several span elements. We'll use a [jsname] attribute to locate our preferred element.